### PR TITLE
Ignores creative & removed unused imports

### DIFF
--- a/src/main/java/com/mrcrayfish/goblintraders/client/renderer/entity/model/GoblinTraderModel.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/client/renderer/entity/model/GoblinTraderModel.java
@@ -7,7 +7,6 @@ import net.minecraft.client.renderer.entity.model.IHasArm;
 import net.minecraft.client.renderer.entity.model.IHasHead;
 import net.minecraft.client.renderer.entity.model.SegmentedModel;
 import net.minecraft.client.renderer.model.ModelRenderer;
-import net.minecraft.util.Hand;
 import net.minecraft.util.HandSide;
 import net.minecraft.util.math.MathHelper;
 

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
@@ -22,6 +22,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.particles.IParticleData;
 import net.minecraft.util.*;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants;
@@ -85,7 +86,7 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
 
     public int getFallCounter()
     {
-        return fallCounter;
+        return this.fallCounter;
     }
 
     @Override
@@ -290,7 +291,7 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
 
     public int getStunDelay()
     {
-        return stunDelay;
+        return this.stunDelay;
     }
 
     public void setDespawnDelay(int despawnDelay)
@@ -300,7 +301,7 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
 
     public int getDespawnDelay()
     {
-        return despawnDelay;
+        return this.despawnDelay;
     }
 
     @Override
@@ -335,6 +336,16 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
         {
             this.remove();
         }
+    }
+
+    protected void spawnParticles(IParticleData particleData) {
+        for(int i = 0; i < 5; ++i) {
+            double d0 = this.rand.nextGaussian() * 0.02D;
+            double d1 = this.rand.nextGaussian() * 0.02D;
+            double d2 = this.rand.nextGaussian() * 0.02D;
+            this.world.addParticle(particleData, this.func_226282_d_(1.0D), this.func_226279_cv_() + 1.0D, this.func_226287_g_(1.0D), d0, d1, d2);
+        }
+
     }
 
     @Nullable

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
@@ -338,16 +338,6 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
         }
     }
 
-    protected void spawnParticles(IParticleData particleData) {
-        for(int i = 0; i < 5; ++i) {
-            double d0 = this.rand.nextGaussian() * 0.02D;
-            double d1 = this.rand.nextGaussian() * 0.02D;
-            double d2 = this.rand.nextGaussian() * 0.02D;
-            this.world.addParticle(particleData, this.func_226282_d_(1.0D), this.func_226279_cv_() + 1.0D, this.func_226287_g_(1.0D), d0, d1, d2);
-        }
-
-    }
-
     @Nullable
     @Override
     protected SoundEvent getAmbientSound()

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/GoblinTrades.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/GoblinTrades.java
@@ -5,12 +5,13 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.EnchantmentData;
-import net.minecraft.enchantment.EnchantmentType;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.merchant.villager.VillagerTrades;
-import net.minecraft.item.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.MerchantOffer;
 import net.minecraft.util.Util;
 
 import javax.annotation.Nullable;

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/AttackRevengeTargetGoal.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/AttackRevengeTargetGoal.java
@@ -3,6 +3,7 @@ package com.mrcrayfish.goblintraders.entity.ai.goal;
 import com.mrcrayfish.goblintraders.entity.AbstractGoblinEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.goal.Goal;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
 
@@ -24,7 +25,7 @@ public class AttackRevengeTargetGoal extends Goal
     @Override
     public boolean shouldExecute()
     {
-        return this.entity.getRevengeTarget() != null && this.entity.getRevengeTarget().isAlive() && this.entity.getDistance(this.entity.getRevengeTarget()) <= 10.0F;
+        return this.entity.getRevengeTarget() != null && this.entity.getRevengeTarget().isAlive() && this.entity.getDistance(this.entity.getRevengeTarget()) <= 10.0F && (!(this.entity.getRevengeTarget() instanceof PlayerEntity) || !((PlayerEntity)this.entity.getRevengeTarget()).isCreative());
     }
 
     @Override

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/FindAppleGoal.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/FindAppleGoal.java
@@ -3,10 +3,7 @@ package com.mrcrayfish.goblintraders.entity.ai.goal;
 import com.mrcrayfish.goblintraders.entity.AbstractGoblinEntity;
 import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.entity.item.ItemEntity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.Hand;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 


### PR DESCRIPTION
Goblin now ignores players in Creative Mode, using the `shouldContinueExecuting` method of the revenge target goal. (Checks if entity is not player, or is player without creative mode). Also removed a few unused imports and cleaned up small portions of code.