### PR TITLE
Port to 1.16.3 (Forge 1.16.3-34.0.10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,14 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 
-version = '1.2.0-1.15.2'
+version = '1.2.1-1.16.1'
 group = 'com.mrcrayfish'
 archivesBaseName = 'goblintraders'
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
 minecraft {
-    mappings channel: 'snapshot', version: '20200122-1.15.1'
+    mappings channel: 'snapshot', version: '20200514-1.16'
     runs {
         client {
             workingDirectory project.file('run')
@@ -57,7 +57,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.15.2-31.1.0'
+    minecraft 'net.minecraftforge:forge:1.16.1-32.0.108'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,14 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 
-version = '1.2.1-1.16.1'
+version = '1.2.2-1.16.3'
 group = 'com.mrcrayfish'
 archivesBaseName = 'goblintraders'
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
 minecraft {
-    mappings channel: 'snapshot', version: '20200514-1.16'
+    mappings channel: 'snapshot', version: '20200916-1.16.2'
     runs {
         client {
             workingDirectory project.file('run')
@@ -57,7 +57,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.16.1-32.0.108'
+    minecraft 'net.minecraftforge:forge:1.16.3-34.1.10'
 }
 
 jar {

--- a/src/main/java/com/mrcrayfish/goblintraders/GoblinTraders.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/GoblinTraders.java
@@ -1,6 +1,7 @@
 package com.mrcrayfish.goblintraders;
 
 import com.mrcrayfish.goblintraders.client.ClientHandler;
+import com.mrcrayfish.goblintraders.init.ModEntities;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.EnchantedBookItem;
@@ -11,6 +12,7 @@ import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 import java.util.Map;
@@ -24,10 +26,16 @@ public class GoblinTraders
     public GoblinTraders()
     {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onClientSetup);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
     }
 
     private void onClientSetup(FMLClientSetupEvent event)
     {
         ClientHandler.setup();
+    }
+
+    private void onCommonSetup(FMLCommonSetupEvent event)
+    {
+        ModEntities.registerEntityTypeAttributes();
     }
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/client/renderer/entity/GoblinTraderRenderer.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/client/renderer/entity/GoblinTraderRenderer.java
@@ -4,11 +4,11 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mrcrayfish.goblintraders.client.renderer.entity.model.GoblinTraderModel;
 import com.mrcrayfish.goblintraders.entity.AbstractGoblinEntity;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
-import net.minecraft.client.renderer.Vector3f;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.client.renderer.entity.layers.HeldItemLayer;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.vector.Vector3f;
 
 /**
  * Author: MrCrayfish
@@ -34,7 +34,7 @@ public class GoblinTraderRenderer extends MobRenderer<AbstractGoblinEntity, Gobl
         if(entity.getDataManager().get(AbstractGoblinEntity.STUNNED))
         {
             float progress = Math.min(10F, entity.getFallCounter() + partialTicks) / 10F;
-            matrixStack.rotate(Vector3f.field_229179_b_.func_229187_a_(90F * progress));
+            matrixStack.rotate(Vector3f.XP.rotationDegrees(90F * progress));
             matrixStack.translate(0, -0.5 * progress, 0);
         }
         super.render(entity, f1, partialTicks, matrixStack, renderTypeBuffer, light);

--- a/src/main/java/com/mrcrayfish/goblintraders/client/renderer/entity/model/GoblinTraderModel.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/client/renderer/entity/model/GoblinTraderModel.java
@@ -82,13 +82,13 @@ public class GoblinTraderModel extends SegmentedModel<AbstractGoblinEntity> impl
     }
 
     @Override
-    public Iterable<ModelRenderer> func_225601_a_()
+    public Iterable<ModelRenderer> getParts()
     {
         return this.parts;
     }
 
     @Override
-    public void render(AbstractGoblinEntity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float headYaw, float headPitch)
+    public void setRotationAngles(AbstractGoblinEntity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float headYaw, float headPitch)
     {
         float rotateFactor;
         rotateFactor = (float) entity.getMotion().lengthSquared();
@@ -137,15 +137,15 @@ public class GoblinTraderModel extends SegmentedModel<AbstractGoblinEntity> impl
     }
 
     @Override
-    public void func_225599_a_(HandSide handSide, MatrixStack matrixStack)
+    public void translateHand(HandSide handSide, MatrixStack matrixStack)
     {
         switch(handSide)
         {
             case LEFT:
-                this.leftArm.setAnglesAndRotation(matrixStack);
+                this.leftArm.translateRotate(matrixStack);
                 break;
             case RIGHT:
-                this.rightArm.setAnglesAndRotation(matrixStack);
+                this.rightArm.translateRotate(matrixStack);
                 matrixStack.translate(0.235, -0.15, 0.25);
                 matrixStack.scale(0.75F, 0.75F, 0.75F);
                 break;

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
@@ -226,7 +226,7 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
     }
 
     @Override
-    public boolean func_213705_dZ()
+    public boolean hasXPBar()
     {
         return false;
     }
@@ -249,7 +249,7 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
         ItemStack heldItem = player.getHeldItem(hand);
         if(heldItem.getItem() == Items.NAME_TAG)
         {
-            heldItem.func_111282_a_(player, this, hand);
+            heldItem.interactWithEntity(player, this, hand);
             return ActionResultType.SUCCESS;
         }
         else if(this.isAlive() && !this.hasCustomer() && !this.isChild()) //TODO check for egg
@@ -354,7 +354,7 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
     public static AttributeModifierMap.MutableAttribute prepareAttributes()
     {
         return MobEntity.func_233666_p_()
-                .func_233815_a_(Attributes.field_233818_a_, 20D) // MAX_HEALTH
-                .func_233815_a_(Attributes.field_233821_d_, 0.7D); // MOVEMENT_SPEED
+                .createMutableAttribute(Attributes.MAX_HEALTH, 20D) // MAX_HEALTH
+                .createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.7D); // MOVEMENT_SPEED
     }
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/AbstractGoblinEntity.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.CreatureEntity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.INPC;
 import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.ai.attributes.AttributeModifierMap;
+import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.merchant.IMerchant;
 import net.minecraft.entity.merchant.villager.VillagerTrades;
@@ -242,28 +244,28 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
     }
 
     @Override
-    protected boolean processInteract(PlayerEntity player, Hand hand)
+    protected ActionResultType func_230254_b_(PlayerEntity player, Hand hand)
     {
         ItemStack heldItem = player.getHeldItem(hand);
         if(heldItem.getItem() == Items.NAME_TAG)
         {
-            heldItem.interactWithEntity(player, this, hand);
-            return true;
+            heldItem.func_111282_a_(player, this, hand);
+            return ActionResultType.SUCCESS;
         }
         else if(this.isAlive() && !this.hasCustomer() && !this.isChild()) //TODO check for egg
         {
             if(this.getOffers().isEmpty())
             {
-                return super.processInteract(player, hand);
+                return super.func_230254_b_(player, hand);
             }
             else if(!this.world.isRemote && (this.getRevengeTarget() == null || this.getRevengeTarget() != player))
             {
                 this.setCustomer(player);
                 this.openMerchantContainer(player, this.getDisplayName(), 1);
             }
-            return true;
+            return ActionResultType.SUCCESS;
         }
-        return super.processInteract(player, hand);
+        return super.func_230254_b_(player, hand);
     }
 
     public boolean isPreviousCustomer(PlayerEntity player)
@@ -348,4 +350,11 @@ public abstract class AbstractGoblinEntity extends CreatureEntity implements INP
     }
 
     public abstract ItemStack getFavouriteFood();
+
+    public static AttributeModifierMap.MutableAttribute prepareAttributes()
+    {
+        return MobEntity.func_233666_p_()
+                .func_233815_a_(Attributes.field_233818_a_, 20D) // MAX_HEALTH
+                .func_233815_a_(Attributes.field_233821_d_, 0.7D); // MOVEMENT_SPEED
+    }
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/TradeWithPlayerGoal.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/TradeWithPlayerGoal.java
@@ -30,7 +30,7 @@ public class TradeWithPlayerGoal extends Goal
         {
             return false;
         }
-        else if(!this.entity.onGround)
+        else if(!this.entity.func_233570_aj_())
         {
             return false;
         }

--- a/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/TradeWithPlayerGoal.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/entity/ai/goal/TradeWithPlayerGoal.java
@@ -30,7 +30,7 @@ public class TradeWithPlayerGoal extends Goal
         {
             return false;
         }
-        else if(!this.entity.func_233570_aj_())
+        else if(!this.entity.isOnGround())
         {
             return false;
         }

--- a/src/main/java/com/mrcrayfish/goblintraders/init/ModEntities.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/init/ModEntities.java
@@ -48,7 +48,7 @@ public class ModEntities
 
     public static void registerEntityTypeAttributes()
     {
-        GlobalEntityTypeAttributes.put(GOBLIN_TRADER, GoblinTraderEntity.prepareAttributes().func_233813_a_());
-        GlobalEntityTypeAttributes.put(VEIN_GOBLIN_TRADER, VeinGoblinTraderEntity.prepareAttributes().func_233813_a_());
+        GlobalEntityTypeAttributes.put(GOBLIN_TRADER, GoblinTraderEntity.prepareAttributes().create());
+        GlobalEntityTypeAttributes.put(VEIN_GOBLIN_TRADER, VeinGoblinTraderEntity.prepareAttributes().create());
     }
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/init/ModEntities.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/init/ModEntities.java
@@ -1,11 +1,13 @@
 package com.mrcrayfish.goblintraders.init;
 
 import com.mrcrayfish.goblintraders.Reference;
+import com.mrcrayfish.goblintraders.entity.AbstractGoblinEntity;
 import com.mrcrayfish.goblintraders.entity.GoblinTraderEntity;
 import com.mrcrayfish.goblintraders.entity.VeinGoblinTraderEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ai.attributes.GlobalEntityTypeAttributes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.event.RegistryEvent;
@@ -42,5 +44,11 @@ public class ModEntities
     {
         IForgeRegistry<EntityType<?>> registry = event.getRegistry();
         ENTITY_TYPES.forEach(registry::register);
+    }
+
+    public static void registerEntityTypeAttributes()
+    {
+        GlobalEntityTypeAttributes.put(GOBLIN_TRADER, GoblinTraderEntity.prepareAttributes().func_233813_a_());
+        GlobalEntityTypeAttributes.put(VEIN_GOBLIN_TRADER, VeinGoblinTraderEntity.prepareAttributes().func_233813_a_());
     }
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderData.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderData.java
@@ -4,7 +4,7 @@ import com.mrcrayfish.goblintraders.Reference;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.dimension.DimensionType;
+import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.WorldSavedData;
 import net.minecraftforge.common.util.Constants;
@@ -80,7 +80,7 @@ public class GoblinTraderData extends WorldSavedData
 
     public static GoblinTraderData get(MinecraftServer server)
     {
-        ServerWorld world = server.getWorld(DimensionType.OVERWORLD);
+        ServerWorld world = server.getWorld(World.field_234918_g_);
         return world.getSavedData().getOrCreate(GoblinTraderData::new, DATA_NAME);
     }
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderData.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderData.java
@@ -80,7 +80,7 @@ public class GoblinTraderData extends WorldSavedData
 
     public static GoblinTraderData get(MinecraftServer server)
     {
-        ServerWorld world = server.getWorld(World.field_234918_g_);
+        ServerWorld world = server.getWorld(World.OVERWORLD);
         return world.getSavedData().getOrCreate(GoblinTraderData::new, DATA_NAME);
     }
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderSpawner.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderSpawner.java
@@ -14,7 +14,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
-import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.spawner.WorldEntitySpawner;
 import net.minecraftforge.event.TickEvent;
@@ -98,8 +97,7 @@ public class GoblinTraderSpawner
     private boolean spawnTrader()
     {
         //List<PlayerEntity> players = this.world.getServer().getPlayerList().getPlayers().stream().filter(player -> player.dimension == this.world.getDimension().getType() && player.isAlive()).collect(Collectors.toList());
-        List<PlayerEntity> players = new ArrayList<>(this.world.getServer().getPlayerList().getPlayers());
-        players = players.stream().filter(player -> player.dimension == this.world.getDimension().getType()).collect(Collectors.toList());
+        List<PlayerEntity> players = new ArrayList<>(this.world.getPlayers());
         if(players.isEmpty())
         {
             return false;
@@ -115,7 +113,7 @@ public class GoblinTraderSpawner
         }
         else
         {
-            BlockPos blockpos = randomPlayer.getPosition();
+            BlockPos blockpos = randomPlayer.func_233580_cy_();
             BlockPos safestPos = this.getSafePositionAroundPlayer(randomPlayer.world, blockpos, 10);
             if(safestPos != null && this.isEmptyCollision(randomPlayer.world, safestPos))
             {
@@ -206,8 +204,8 @@ public class GoblinTraderSpawner
     {
         MinecraftServer server = event.getServer();
         GoblinTraderData traderData = GoblinTraderData.get(server);
-        spawners.add(new GoblinTraderSpawner(server.getWorld(DimensionType.OVERWORLD), traderData.getGoblinData("GoblinTrader"), ModEntities.GOBLIN_TRADER, 0, 64));
-        spawners.add(new GoblinTraderSpawner(server.getWorld(DimensionType.THE_NETHER), traderData.getGoblinData("VeinGoblinTrader"), ModEntities.VEIN_GOBLIN_TRADER, 0, 128));
+        spawners.add(new GoblinTraderSpawner(server.getWorld(World.field_234918_g_), traderData.getGoblinData("GoblinTrader"), ModEntities.GOBLIN_TRADER, 0, 64));
+        spawners.add(new GoblinTraderSpawner(server.getWorld(World.field_234919_h_), traderData.getGoblinData("VeinGoblinTrader"), ModEntities.VEIN_GOBLIN_TRADER, 0, 128));
     }
 
     @SubscribeEvent
@@ -225,7 +223,7 @@ public class GoblinTraderSpawner
         if(event.side != LogicalSide.SERVER)
             return;
 
-        if(!event.world.getDimension().isSurfaceWorld())
+        if(!event.world.func_234923_W_().equals(World.field_234918_g_))
             return;
 
         spawners.forEach(GoblinTraderSpawner::tick);

--- a/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderSpawner.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderSpawner.java
@@ -9,9 +9,11 @@ import net.minecraft.entity.EntitySpawnPlacementRegistry;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
@@ -66,7 +68,7 @@ public class GoblinTraderSpawner
 
     private void tick()
     {
-        if(this.world.getGameRules().getBoolean(GameRules.field_230128_E_))
+        if(this.world.getGameRules().getBoolean(GameRules.DO_TRADER_SPAWNING))
         {
             if(--this.delayBeforeSpawnLogic <= 0)
             {
@@ -113,7 +115,7 @@ public class GoblinTraderSpawner
         }
         else
         {
-            BlockPos blockpos = randomPlayer.func_233580_cy_();
+            BlockPos blockpos = randomPlayer.getPosition();
             BlockPos safestPos = this.getSafePositionAroundPlayer(randomPlayer.world, blockpos, 10);
             if(safestPos != null && this.isEmptyCollision(randomPlayer.world, safestPos))
             {
@@ -121,7 +123,7 @@ public class GoblinTraderSpawner
                 {
                     return false;
                 }
-                AbstractGoblinEntity goblin = this.entityType.spawn(randomPlayer.world, null, null, null, safestPos, SpawnReason.EVENT, false, false);
+                AbstractGoblinEntity goblin = this.entityType.spawn((ServerWorld) randomPlayer.world, (CompoundNBT) null, (ITextComponent) null, (PlayerEntity) null, safestPos, SpawnReason.EVENT, false, false);
                 if(goblin != null)
                 {
                     this.data.setGoblinTraderId(goblin.getUniqueID());
@@ -204,8 +206,8 @@ public class GoblinTraderSpawner
     {
         MinecraftServer server = event.getServer();
         GoblinTraderData traderData = GoblinTraderData.get(server);
-        spawners.add(new GoblinTraderSpawner(server.getWorld(World.field_234918_g_), traderData.getGoblinData("GoblinTrader"), ModEntities.GOBLIN_TRADER, 0, 64));
-        spawners.add(new GoblinTraderSpawner(server.getWorld(World.field_234919_h_), traderData.getGoblinData("VeinGoblinTrader"), ModEntities.VEIN_GOBLIN_TRADER, 0, 128));
+        spawners.add(new GoblinTraderSpawner(server.getWorld(World.OVERWORLD), traderData.getGoblinData("GoblinTrader"), ModEntities.GOBLIN_TRADER, 0, 64));
+        spawners.add(new GoblinTraderSpawner(server.getWorld(World.THE_NETHER), traderData.getGoblinData("VeinGoblinTrader"), ModEntities.VEIN_GOBLIN_TRADER, 0, 128));
     }
 
     @SubscribeEvent
@@ -223,7 +225,7 @@ public class GoblinTraderSpawner
         if(event.side != LogicalSide.SERVER)
             return;
 
-        if(!event.world.func_234923_W_().equals(World.field_234918_g_))
+        if(!event.world.getDimensionKey().equals(World.OVERWORLD))
             return;
 
         spawners.forEach(GoblinTraderSpawner::tick);

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,11 +1,12 @@
 modLoader="javafml"
-loaderVersion="[32,)"
+loaderVersion="[34,)"
+license="All rights reserved"
 
 issueTrackerURL="https://github.com/MrCrayfish/GoblinTraders/issues"
 
 [[mods]]
 modId="goblintraders"
-version="1.2.1"
+version="1.2.2"
 displayName="Goblin Traders"
 updateJSONURL="https://raw.githubusercontent.com/MrCrayfish/ModUpdates/master/goblintraders/update.json"
 displayURL="https://mrcrayfish.com/mods?id=goblintraders"
@@ -17,12 +18,12 @@ description='Adds goblins that trade speical items with the player!'
 [[dependencies.goblintraders]]
     modId="forge"
     mandatory=true
-    versionRange="[32,)"
+    versionRange="[34,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.goblintraders]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16,)"
+    versionRange="[1.16.3]"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,11 +1,11 @@
 modLoader="javafml"
-loaderVersion="[31,)"
+loaderVersion="[32,)"
 
 issueTrackerURL="https://github.com/MrCrayfish/GoblinTraders/issues"
 
 [[mods]]
 modId="goblintraders"
-version="1.2.0"
+version="1.2.1"
 displayName="Goblin Traders"
 updateJSONURL="https://raw.githubusercontent.com/MrCrayfish/ModUpdates/master/goblintraders/update.json"
 displayURL="https://mrcrayfish.com/mods?id=goblintraders"
@@ -17,12 +17,12 @@ description='Adds goblins that trade speical items with the player!'
 [[dependencies.goblintraders]]
     modId="forge"
     mandatory=true
-    versionRange="[31,)"
+    versionRange="[32,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.goblintraders]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.15.2,1.16)"
+    versionRange="[1.16,)"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "goblintraders resources",
-        "pack_format": 5,
-        "_comment": "A pack_format of 5 requires json lang files and some texture changes from 1.15. Note: we require v5 pack meta for all mods."
+        "pack_format": 6,
+        "_comment": "A pack_format of 6 requires json lang files and some texture changes from 1.16.3. Note: we require v6 pack meta for all mods."
     }
 }


### PR DESCRIPTION
This is a port to 1.16.1 from 1.15.2.
I have tested everything from spawning the entities to the coremods.
This version works on the client and on the server.

Most changes were just made compatible with the new mappings / method signatures etc.
However, since 1.16 some entity attributes must now be registered by the mod, so I had to add a call to GlobalEntityTypeAttributes#put inside the common setup phase.
Inside the AbstractGoblinEntity class I also added a new method called prepareAttributes in which the Attributes are registered.
The values I used are from the 1.15.2 build of GoblinTraders.

This is only a port, there are no new trade offers for 1.16 items yet.