### PR TITLE
Prevent constant log spam, but in 1.15.2.

### DIFF
--- a/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderSpawner.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/world/spawner/GoblinTraderSpawner.java
@@ -162,7 +162,6 @@ public class GoblinTraderSpawner
     @Nullable
     private BlockPos findGround(World world, BlockPos pos, int maxDistance)
     {
-        System.out.println(world.getBlockState(pos).getBlock().getRegistryName());
         if(world.isAirBlock(pos))
         {
             BlockPos downPos = pos;


### PR DESCRIPTION
This is making logs really really hard to parse, since pages of text are full of block IDs.

Same as #23 but for 1.15.2.