### PR TITLE
Updated to Minecraft 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'maven-publish'
 apply plugin: 'eclipse'
 
-version = '1.7.0-1.18.1'
+version = '1.7.0-1.18.2'
 group = 'com.mrcrayfish'
 archivesBaseName = 'goblintraders'
 
@@ -27,7 +27,7 @@ mixin {
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 minecraft {
-    mappings channel: 'official', version: '1.18.1'
+    mappings channel: 'official', version: '1.18.2'
     runs {
         client {
             workingDirectory project.file('run')
@@ -75,7 +75,7 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.18.1-39.0.0'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.0.32'
     implementation fg.deobf('curse.maven:catalogue-459701:3543625')
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }

--- a/src/main/java/com/mrcrayfish/goblintraders/init/ModEntities.java
+++ b/src/main/java/com/mrcrayfish/goblintraders/init/ModEntities.java
@@ -33,8 +33,7 @@ public class ModEntities
 
     private static <T extends Entity> RegistryObject<EntityType<T>> build(String id, Function<Level, T> function, float width, float height)
     {
-        EntityType<T> type = EntityType.Builder.<T>of((entityType, world) -> function.apply(world), MobCategory.CREATURE).sized(width, height).setCustomClientFactory((spawnEntity, world) -> function.apply(world)).build(id);
-        return REGISTER.register(id, () -> type);
+        return REGISTER.register(id, () -> EntityType.Builder.<T>of((entityType, world) -> function.apply(world), MobCategory.CREATURE).sized(width, height).setCustomClientFactory((spawnEntity, world) -> function.apply(world)).build(id));
     }
 
     @SubscribeEvent

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[39,)"
+loaderVersion="[40,)"
 license="All rights reserved"
 
 issueTrackerURL="https://github.com/MrCrayfish/GoblinTraders/issues"
@@ -18,7 +18,7 @@ description='Adds goblins that have unique trades to improve your adventure!'
 [[dependencies.goblintraders]]
     modId="forge"
     mandatory=true
-    versionRange="[39,)"
+    versionRange="[40,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.goblintraders]]

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "goblintraders resources",
-        "pack_format": 6,
+        "pack_format": 8,
         "_comment": "A pack_format of 6 requires json lang files and some texture changes from 1.16.3. Note: we require v6 pack meta for all mods."
     }
 }


### PR DESCRIPTION
The initialization of the EntityType was being called too late resulting in a `Registry is already frozen` exception.