### PR TITLE
Fix goblin trades losing their XP reward when the entity reloads

### DIFF
--- a/common/src/main/java/com/mrcrayfish/goblintraders/trades/GoblinMerchantOffer.java
+++ b/common/src/main/java/com/mrcrayfish/goblintraders/trades/GoblinMerchantOffer.java
@@ -13,7 +13,7 @@ public class GoblinMerchantOffer extends MerchantOffer
 {
     public GoblinMerchantOffer(MerchantOffer offer)
     {
-        super(offer.getItemCostA(), offer.getItemCostB(), offer.getResult(), offer.getUses(), offer.getMaxUses(), offer.getDemand(), offer.getPriceMultiplier(), offer.getXp());
+        super(offer.getItemCostA(), offer.getItemCostB(), offer.getResult(), offer.getUses(), offer.getMaxUses(), offer.getXp(), offer.getPriceMultiplier(), offer.getDemand());
     }
 
     public GoblinMerchantOffer(ItemCost paymentStack, Optional<ItemCost> secondaryPaymentStack, ItemStack offerStack, int maxUses, int experience, float priceMultiplier)


### PR DESCRIPTION
Fixes #116.

`GoblinMerchantOffer`'s copy constructor passes two of its arguments in the wrong order:

```java
super(offer.getItemCostA(), offer.getItemCostB(), offer.getResult(),
      offer.getUses(), offer.getMaxUses(),
      offer.getDemand(),          // lands in the xp parameter
      offer.getPriceMultiplier(),
      offer.getXp());             // lands in the demand parameter
```

Vanilla's signature is:

```java
MerchantOffer(ItemCost baseCostA, Optional<ItemCost> costB, ItemStack result,
              int uses, int maxUses, int xp, float priceMultiplier, int demand)
```

so `xp` and `demand` are swapped.

That constructor is called from `GoblinOffers(CompoundTag)`, which runs on **every deserialise**. So the two values trade places each time a goblin is loaded: the `experience` from the trade JSON moves into `demand`, and `xp` becomes 0. `ExperienceOrb.award()` returns immediately when the amount is `<= 0`, so no orbs drop at all.

Because it's a swap rather than a reset, it toggles — broken after one reload, fine after the next. That's why it reads as intermittent, and why picking a goblin up and putting it back down with a cage (one extra serialise/deserialise round trip) appears to fix it for a session.

### Evidence

Entity NBT from my 1.21.1 Fabric server. `common.json` defines this trade as `"experience": 6, "max_trades": 30`.

A freshly spawned goblin:

```
xp=6  maxUses=30  demand=<absent>   sell=2x iron_ingot  buy=1x raw_iron
```

The same trade after the chunk unloaded and reloaded once:

```
xp=0  maxUses=30  demand=6          sell=2x iron_ingot  buy=1x raw_iron
```

The experience value isn't lost, it's just in the wrong field. Across 14 goblins, 10 were in the `xp=0 / demand=<experience>` state and 4 were still intact — the difference being how many times each had been round-tripped. Every `demand` value matched the `experience` in the mod's own trade JSONs exactly (4, 6, 10, 100, 300).

After applying this patch I forced those chunks through a full load/save cycle; all 14 goblins kept their `xp` values, where previously that cycle zeroed them.

### Other branches

The same line is present on every branch I looked at, including `multiloader/26.1`, so this isn't specific to 1.21.1. Happy to open the same PR against the others if that's useful.

### Note for existing worlds

Fixing the constructor doesn't recover goblins that already have `xp: 0` on disk — once the round trip is faithful it will preserve the 0. Restocking only resets `uses`, it never regenerates offers, so those entities need their NBT repaired (move `demand` back into `xp`). Might be worth a line in the changelog.
